### PR TITLE
Fix openapi parameter handling

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -9,7 +9,8 @@ const createJestConfig = nextJest({
 // Add any custom config to be passed to Jest
 const config: Config = {
   coverageProvider: "v8",
-  testEnvironment: "jsdom"
+  testEnvironment: "jsdom",
+  testPathIgnorePatterns: ["/node_modules/", "__tests__/playwright-test/"]
   // Add more setup options before each test is run
   // setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
 }

--- a/lib/openapi-conversion.ts
+++ b/lib/openapi-conversion.ts
@@ -126,15 +126,15 @@ export const openapiToFunctions = async (
       if (params.length > 0) {
         const paramProperties = params.reduce((acc: any, param: any) => {
           if (param.schema) {
-            acc[param.name] = param.schema
+            acc[param.name] = {
+              ...param.schema,
+              ...(param.required ? { required: true } : {})
+            }
           }
           return acc
         }, {})
 
-        schema.properties.parameters = {
-          type: "object",
-          properties: paramProperties
-        }
+        Object.assign(schema.properties, paramProperties)
       }
 
       functions.push({


### PR DESCRIPTION
## Summary
- ensure openapi parameters are exposed directly in `openapiToFunctions`
- ignore playwright folder in jest config

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_686bc25f0a608333aad6aec0f014d628